### PR TITLE
Fix build failure caused by postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "test": "echo \"No tests specified\"",
-    "postinstall": "node dist/index.js --check-binary"
+    "postinstall": "test -f dist/index.js && node dist/index.js --check-binary || echo 'Skipping binary check (dist not built yet)'"
   },
   "keywords": [
     "hexdocs",


### PR DESCRIPTION
## Summary
- Fixed npm postinstall script that was causing build failures during initial setup by checking if dist/index.js exists before running