### PR TITLE
Fix ArgumentError when fetching docs with nil version

### DIFF
--- a/lib/hexdocs_mcp/docs.ex
+++ b/lib/hexdocs_mcp/docs.ex
@@ -7,9 +7,11 @@ defmodule HexdocsMcp.Docs do
   @impl Docs
   def fetch(package, version) do
     args =
-      if version == "latest",
-        do: ["hex.docs", "fetch", package],
-        else: ["hex.docs", "fetch", package, version]
+      case version do
+        nil -> ["hex.docs", "fetch", package]
+        "latest" -> ["hex.docs", "fetch", package]
+        version -> ["hex.docs", "fetch", package, version]
+      end
 
     result = System.cmd("mix", args, stderr_to_stdout: true)
 


### PR DESCRIPTION
Handle nil version properly in Docs.fetch/2 to prevent System.cmd/3 from receiving non-binary arguments. This fixes the error that occurs when processing project dependencies without explicit versions.

🤖 Generated with [Claude Code](https://claude.ai/code)